### PR TITLE
updating workflow

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -1,14 +1,14 @@
 name: Release
 
 on:
-  workflow_dispatch:
   pull_request:
     types: [closed]
     branches: [main]
 
 jobs:
-  Release:
-    uses: gesslar/Maint/.github/workflows/ReleaseMuddyInjectMupdate.yaml@main
+  release:
+    if: github.event.pull_request.merged == true
+    uses: gesslar/Maint/.github/workflows/ReleaseMudlet.yaml@main
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR renames `.github/workflows/release.yml` to `.github/workflows/Release.yaml` and makes three functional changes to the release workflow:

- **Adds `if: github.event.pull_request.merged == true`** — a necessary guard that prevents the release job from running when a PR is simply closed without merging. Previously the workflow would trigger on any closed PR.
- **Switches the called reusable workflow** from `ReleaseMuddyInjectMupdate.yaml@main` to `ReleaseMudlet.yaml@main`, which aligns with this repository being a Mudlet package.
- **Removes `workflow_dispatch`** — manual release triggering is no longer available. This appears intentional (keeping releases fully automated through the PR merge flow), but means a release can't be re-run manually if needed (e.g., after a transient CI failure).

The `@main` pin on the reusable workflow satisfies the project's policy for Release workflows.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the `merged == true` guard is the right fix, and the workflow correctly targets `@main` per project policy.

The changes are small and well-reasoned: the added `if` condition prevents spurious runs on closed-but-unmerged PRs, the reusable workflow reference is updated and still pins `@main` per policy, and the rename is cosmetic. No logic errors or security concerns.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["updating workflow"](https://github.com/gesslar/chatter/commit/d8cb005f9f1d095123795a4345eee6ea984f681b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28106263)</sub>

**Context used:**

- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/review/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))

<!-- /greptile_comment -->