### PR TITLE
fixing workflow

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -9,6 +9,8 @@ jobs:
   release:
     if: github.event.pull_request.merged == true
     uses: gesslar/Maint/.github/workflows/ReleaseMudlet.yaml@main
+    with:
+      inject_mupdate: true
     secrets: inherit
     permissions:
       contents: write

--- a/mfile
+++ b/mfile
@@ -1,7 +1,7 @@
 {
   "package": "Chatter",
   "title": "Manage messages on channels in a separate window using GMCP.",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "author": "gesslar",
   "icon": "chat.png",
   "dependencies": "",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the release workflow configuration and updates package metadata. The `.github/workflows/Release.yaml` correctly uses `gesslar/Maint/.github/workflows/ReleaseMudlet.yaml@main`, satisfying the repository policy that Release workflows must target the `@main` branch.

- `.github/workflows/Release.yaml`: References the reusable `ReleaseMudlet.yaml` workflow at `@main`, sets `inject_mupdate: true`, inherits secrets, and grants `contents: write` permission at the job level
- `mfile`: Package metadata file updated (version `2.3.2`)

<h3>Confidence Score: 5/5</h3>

Safe to merge — workflow correctly targets @main per repo policy and no logic issues found.

Both changed files are in good shape. The Release workflow uses @main for the reusable workflow call as required by the custom instruction, the YAML structure (permissions, secrets, with) is valid for a reusable workflow caller job, and the mfile metadata appears well-formed.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["fixing workflow"](https://github.com/gesslar/chatter/commit/e35c92d64379d54206a39c34eef50d3f2a958738) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28253326)</sub>

**Context used:**

- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/review/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))

<!-- /greptile_comment -->